### PR TITLE
Add configuration to limit automatic issue linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ with the following content:
 ---
 jira:
   projectKey: "HSEARCH" # Change to whatever your project key is
-  insertLinksInPullRequests: true # This is optional and enables automatically adding issue links to PR descriptions
+  insertLinksInPullRequests: true # This is optional and enables automatically adding links to Jira issues found in a PR's commits to its description
+  linkIssuesLimit: 3 # This is optional and allows disabling automatic issue links when more than the specified number of keys are found in a PR's commits (defaults to 3)
   # To skip JIRA-related checks (pull request title/body includes JIRA issue keys/links etc.),
   # a list of ignore rules can be configured:
   ignore:

--- a/src/main/java/org/hibernate/infra/bot/EditPullRequestBodyAddIssueLinks.java
+++ b/src/main/java/org/hibernate/infra/bot/EditPullRequestBodyAddIssueLinks.java
@@ -79,6 +79,10 @@ public class EditPullRequestBodyAddIssueLinks {
 			LOG.debug( "Found no issue keys in commits, terminating." );
 			return;
 		}
+		else if ( issueKeys.size() > repositoryConfig.jira.getIssueLinksLimit() ) {
+			LOG.debug( "Found more issues than the configured limit, terminating." );
+			return;
+		}
 
 		final String originalBody = Objects.toString( pullRequest.getBody(), "" );
 

--- a/src/main/java/org/hibernate/infra/bot/config/RepositoryConfig.java
+++ b/src/main/java/org/hibernate/infra/bot/config/RepositoryConfig.java
@@ -15,6 +15,7 @@ public class RepositoryConfig {
 		private Optional<Pattern> issueKeyPattern = Optional.empty();
 
 		private Optional<Boolean> insertLinksInPullRequests = Optional.empty();
+		private Integer issueLinksLimit = 3;
 
 		private List<IgnoreConfiguration> ignore = Collections.emptyList();
 
@@ -34,6 +35,14 @@ public class RepositoryConfig {
 
 		public Optional<Boolean> getInsertLinksInPullRequests() {
 			return insertLinksInPullRequests;
+		}
+
+		public Integer getIssueLinksLimit() {
+			return issueLinksLimit;
+		}
+
+		public void setIssueLinksLimit(Integer issueLinksLimit) {
+			this.issueLinksLimit = issueLinksLimit;
 		}
 
 		public List<IgnoreConfiguration> getIgnore() {

--- a/src/test/java/org/hibernate/infra/bot/tests/EditPullRequestBodyAddIssueLinksTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/EditPullRequestBodyAddIssueLinksTest.java
@@ -15,8 +15,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
@@ -232,4 +234,55 @@ public class EditPullRequestBodyAddIssueLinksTest extends AbstractPullRequestTes
 				} );
 	}
 
+
+	@Test
+	void tooManyIssues() throws IOException {
+		long repoId = 344815557L;
+		long prId = 585627026L;
+		given()
+				.github( mocks -> {
+					mocks.configFile("hibernate-github-bot.yml")
+							.fromString( """
+									jira:
+									  projectKey: "HSEARCH"
+									  insertLinksInPullRequests: true
+									  issueLinksLimit: 3
+									""" );
+
+					GHRepository repoMock = mocks.repository( "yrodiere/hibernate-github-bot-playground" );
+					when( repoMock.getId() ).thenReturn( repoId );
+
+					PullRequestMockHelper.start( mocks, prId, repoMock )
+							.commit( "HSEARCH-1111 Commit 1" )
+							.commit( "HSEARCH-1112 Commit 2" )
+							.commit( "HSEARCH-1113 HSEARCH-1114 HSEARCH-1115 Commit 3" )
+							.commit( "HSEARCH-1116 Commit 4" )
+							.comment( "Some comment" )
+							.comment( "Some other comment" );
+
+					mockCheckRuns( repoMock, "6e9f11a1e2946b207c6eb245ec942f2b5a3ea156" );
+				} )
+				.when()
+				.payloadFromClasspath( "/pullrequest-opened-hsearch-1111.json" )
+				.event( GHEvent.PULL_REQUEST )
+				.then()
+				.github( mocks -> {
+					GHPullRequest prMock = mocks.pullRequest( prId );
+					ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass( String.class );
+					verify( prMock, never() ).setBody( bodyCaptor.capture() );
+					ArgumentCaptor<String> commentCaptor = ArgumentCaptor.forClass( String.class );
+					verify( prMock ).comment( commentCaptor.capture() );
+					assertThat( commentCaptor.getValue() )
+							.isEqualTo( """
+									Thanks for your pull request!
+
+									This pull request does not follow the contribution rules. Could you have a look?
+
+									❌ The PR title or body should list the keys of all JIRA issues mentioned in the commits
+									    ↳ Issue keys mentioned in commits but missing from the PR title or body: [HSEARCH-1112, HSEARCH-1113, HSEARCH-1114, HSEARCH-1115, HSEARCH-1116]
+
+									› This message was automatically generated.""" );
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
 }

--- a/src/test/java/org/hibernate/infra/bot/tests/EditPullRequestBodyAddIssueLinksTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/EditPullRequestBodyAddIssueLinksTest.java
@@ -1,37 +1,23 @@
 package org.hibernate.infra.bot.tests;
 
-import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.infra.bot.tests.PullRequestMockHelper.mockPagedIterable;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
-
 import java.io.IOException;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.quarkiverse.githubapp.testing.GitHubAppTest;
 import io.quarkus.test.junit.QuarkusTest;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.kohsuke.github.GHCheckRun;
-import org.kohsuke.github.GHCheckRunBuilder;
-import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHEvent;
-import org.kohsuke.github.GHIssueComment;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHRepository;
-import org.kohsuke.github.GHUser;
-import org.kohsuke.github.PagedIterable;
-import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @QuarkusTest
 @GitHubAppTest


### PR DESCRIPTION
Adds the `issueLinksLimit` configuration parameter, which defaults to `3`, that disables automatically adding Jira issue links to a PR's body when more than the specified number of keys is found. This is mainly to avoid linking PRs erroneously created against the wrong branch to unrelated issues. 