### PR TITLE
Develocity build scans: link directly to failing tests when there are any

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatter.java
+++ b/src/main/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatter.java
@@ -12,6 +12,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.UriBuilder;
 
 import org.hibernate.infra.bot.config.RepositoryConfig;
 
@@ -110,6 +111,13 @@ public class DevelocityReportFormatter {
 			return switch ( buildScan.status() ) {
 				case SUCCESS -> buildScan.buildScanUri();
 				case FAILURE -> buildScan.failuresUri();
+			};
+		}
+
+		static URI testStatusUri(DevelocityCIBuildScan buildScan) {
+			return switch ( buildScan.testStatus() ) {
+				case SUCCESS -> buildScan.testsUri();
+				case FAILURE -> UriBuilder.fromUri( buildScan.testsUri() ).queryParam( "outcome", "FAILED,FLAKY" ).build();
 			};
 		}
 

--- a/src/main/resources/templates/DevelocityReportFormatter/summary.md
+++ b/src/main/resources/templates/DevelocityReportFormatter/summary.md
@@ -16,7 +16,7 @@ No build scan found for this CI run.
 !}{/for}{!
 !}|{buildScan.goals.spaceDelimited.backQuoted}{!
 !}|[{buildScan.status.circleEmoji}]({buildScan.statusUri} "Build Scan"){!
-!} [{buildScan.testStatus.checkEmoji}]({buildScan.testsUri} "Tests"){!
+!} [{buildScan.testStatus.checkEmoji}]({buildScan.testStatusUri} "Tests"){!
 !} [:page_with_curl:]({buildScan.logsUri} "Logs"){!
 !}|
 {/for}

--- a/src/test/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatterTest.java
+++ b/src/test/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatterTest.java
@@ -107,7 +107,7 @@ class DevelocityReportFormatterTest {
 						|`Linux` `elasticsearch` `elasticsearch-8.13` `h2` `hibernate-search` `jdk-17` `lucene`\
 						|`clean verify`\
 						|[:red_circle:](https://ge.hibernate.org/s/45fv2rr67ofuy/failures "Build Scan")\
-						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests "Tests")\
+						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests?outcome=FAILED%2CFLAKY "Tests")\
 						 [:page_with_curl:](https://ge.hibernate.org/s/45fv2rr67ofuy/console-log "Logs")\
 						|
 						""" );
@@ -236,7 +236,7 @@ class DevelocityReportFormatterTest {
 						|`Linux`|`17`|`es-8.13` `lucene`|`h2`\
 						|`clean verify`\
 						|[:red_circle:](https://ge.hibernate.org/s/45fv2rr67ofuy/failures "Build Scan")\
-						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests "Tests")\
+						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests?outcome=FAILED%2CFLAKY "Tests")\
 						 [:page_with_curl:](https://ge.hibernate.org/s/45fv2rr67ofuy/console-log "Logs")\
 						|
 								""" );


### PR DESCRIPTION
E.g. link to https://ge.hibernate.org/s/pmvpufessjcge/tests?outcome=FAILED,FLAKY instead of https://ge.hibernate.org/s/pmvpufessjcge/tests

Not a life-changer, but it's still one fewer click to get tot the relevant information.