### PR TITLE
Fix syntax of links to failed test reports

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatter.java
+++ b/src/main/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatter.java
@@ -117,7 +117,7 @@ public class DevelocityReportFormatter {
 		static URI testStatusUri(DevelocityCIBuildScan buildScan) {
 			return switch ( buildScan.testStatus() ) {
 				case SUCCESS -> buildScan.testsUri();
-				case FAILURE -> UriBuilder.fromUri( buildScan.testsUri() ).queryParam( "outcome", "FAILED,FLAKY" ).build();
+				case FAILURE -> UriBuilder.fromUri( buildScan.testsUri() ).queryParam( "outcome", "FAILED", "FLAKY" ).build();
 			};
 		}
 

--- a/src/test/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatterTest.java
+++ b/src/test/java/org/hibernate/infra/bot/develocity/DevelocityReportFormatterTest.java
@@ -107,7 +107,7 @@ class DevelocityReportFormatterTest {
 						|`Linux` `elasticsearch` `elasticsearch-8.13` `h2` `hibernate-search` `jdk-17` `lucene`\
 						|`clean verify`\
 						|[:red_circle:](https://ge.hibernate.org/s/45fv2rr67ofuy/failures "Build Scan")\
-						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests?outcome=FAILED%2CFLAKY "Tests")\
+						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests?outcome=FAILED&outcome=FLAKY "Tests")\
 						 [:page_with_curl:](https://ge.hibernate.org/s/45fv2rr67ofuy/console-log "Logs")\
 						|
 						""" );
@@ -236,7 +236,7 @@ class DevelocityReportFormatterTest {
 						|`Linux`|`17`|`es-8.13` `lucene`|`h2`\
 						|`clean verify`\
 						|[:red_circle:](https://ge.hibernate.org/s/45fv2rr67ofuy/failures "Build Scan")\
-						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests?outcome=FAILED%2CFLAKY "Tests")\
+						 [:x:](https://ge.hibernate.org/s/45fv2rr67ofuy/tests?outcome=FAILED&outcome=FLAKY "Tests")\
 						 [:page_with_curl:](https://ge.hibernate.org/s/45fv2rr67ofuy/console-log "Logs")\
 						|
 								""" );


### PR DESCRIPTION
The previous link was invalid.