### PR TITLE
Add links to the web search in Develocity reports

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/util/ClockProducer.java
+++ b/src/main/java/org/hibernate/infra/bot/util/ClockProducer.java
@@ -1,0 +1,19 @@
+package org.hibernate.infra.bot.util;
+
+import java.time.Clock;
+
+import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class ClockProducer {
+
+    @Produces
+    @ApplicationScoped
+    @Unremovable
+    Clock clock() {
+        return Clock.systemUTC();
+    }
+
+}

--- a/src/main/resources/templates/DevelocityReportFormatter/footer.md
+++ b/src/main/resources/templates/DevelocityReportFormatter/footer.md
@@ -1,0 +1,11 @@
+
+
+Didn't find your build? Try [this search query]({develocity:webSearchUri(query)})
+{#if debug}
+
+Full query sent to Develocity:
+
+```
+{develocity:formatQuery(query)}
+```
+{/if}


### PR DESCRIPTION
For now it's not very useful given the query is just a list of CI runs we found, but it might still help with debugging, and also if we build the query differently in the future (e.g. match by PR tag + commit SHA).