### PR TITLE
Change to the pattern in the user check of the ignore config

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -246,7 +246,7 @@ public class CheckPullRequestContributionRules {
 			GHUser author = context.pullRequest.getUser();
 			String title = context.pullRequest.getTitle();
 			for ( RepositoryConfig.IgnoreConfiguration ignore : ignoredPRConfigurations ) {
-				if ( ignore.getUser().equals( author.getLogin() )
+				if ( ignore.getUserPattern().matcher( author.getLogin() ).matches()
 						&& ignore.getTitlePattern().matcher( title ).matches() ) {
 					return false;
 				}

--- a/src/main/java/org/hibernate/infra/bot/config/RepositoryConfig.java
+++ b/src/main/java/org/hibernate/infra/bot/config/RepositoryConfig.java
@@ -67,15 +67,15 @@ public class RepositoryConfig {
 
 	public static class IgnoreConfiguration {
 
-		private String user;
+		private Pattern userPattern;
 		private Pattern titlePattern;
 
-		public String getUser() {
-			return user;
+		public Pattern getUserPattern() {
+			return userPattern;
 		}
 
-		public void setUser(String user) {
-			this.user = user;
+		public void setUserPattern(String userPattern) {
+			this.userPattern = Patterns.compile( userPattern );
 		}
 
 		public Pattern getTitlePattern() {

--- a/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesJiraTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesJiraTest.java
@@ -286,7 +286,7 @@ public class CheckPullRequestContributionRulesJiraTest extends AbstractPullReque
 									jira:
 									  projectKey: "HSEARCH"
 									  ignore:
-									    - user: dependabot[bot]
+									    - userPattern: dependabot\\[bot\\]
 									      titlePattern: ".*\\\\bmaven\\\\b.*\\\\bplugin\\\\b.*"
 									""" );
 


### PR DESCRIPTION
I'm thinking we can ask the bot to ignore checks for these ORM backport PRs https://github.com/hibernate/hibernate-orm/pull/9343 
but since anyone on the ORM team can open them ... adding a line per GH user with the same title pattern seemed like a lot of copy-pasting 😄 hence, maybe let's have the pattern for the user as well?