### PR TITLE
Explicitly install OC as one of the build steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           version: 'v3.13.3'
 
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          oc: "latest"
+
       - name: Log in to OpenShift
         uses: redhat-actions/oc-login@v1
         with:


### PR DESCRIPTION
> Error: Error: Unable to locate executable file: oc. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.

https://github.com/hibernate/hibernate-github-bot/actions/runs/12347663679/job/34466352632

`oc` should've been installed by default according to the https://github.com/redhat-actions/oc-login/blob/dfbd9912672664f9df2023c1c16e07bcf306043c/README.md#getting-started 

but the build complains about it 😖 

looking at the logs of this failing deploy-build:
```
Operating System
  Ubuntu
  24.04.1
  LTS
```

and in the others e.g. for search.quarkus.io:
```
Operating System
  Ubuntu
  22.04.5
  LTS
```

Both request a `ubuntu-latest`... according to https://github.com/actions/runner-images/blob/5c8a14c94ce4ce691feb225859daa030c5ff896f/README.md it should've been a 22... 

Do we report this to the runner-images or .... (since oc should be available by default on these...)