### PR TITLE
Use the same "new line" char sequence when comparing the license agreement

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -18,6 +18,7 @@ import org.hibernate.infra.bot.config.DeploymentConfig;
 import org.hibernate.infra.bot.config.RepositoryConfig;
 import org.hibernate.infra.bot.util.CommitMessages;
 import org.hibernate.infra.bot.util.GlobMatcher;
+import org.hibernate.infra.bot.util.Patterns;
 
 import org.jboss.logging.Logger;
 
@@ -283,12 +284,12 @@ public class CheckPullRequestContributionRules {
 
 		protected LicenseCheck(String agreementText) {
 			super( "Contribution — License agreement" );
-			this.agreementText = agreementText;
+			this.agreementText = Patterns.sanitizeNewLines( agreementText );
 		}
 
 		@Override
 		public void perform(PullRequestCheckRunContext context, PullRequestCheckRunOutput output) {
-			String body = context.pullRequest.getBody();
+			String body = Patterns.sanitizeNewLines( context.pullRequest.getBody() );
 			PullRequestCheckRunRule rule = output.rule( "The pull request description must contain the license agreement text." );
 			if ( body != null && body.contains( agreementText ) ) {
 				rule.passed();

--- a/src/main/java/org/hibernate/infra/bot/EditPullRequestBodyAddTaskList.java
+++ b/src/main/java/org/hibernate/infra/bot/EditPullRequestBodyAddTaskList.java
@@ -34,7 +34,6 @@ public class EditPullRequestBodyAddTaskList {
 	private static final String START_MARKER = "<!-- Hibernate GitHub Bot task list start -->";
 
 	private static final String END_MARKER = "<!-- Hibernate GitHub Bot task list end -->";
-	private static final Set<Character> REGEX_ESCAPE_CHARS = Set.of( '(', ')', '[', ']', '{', '}', '\\', '.', '?', '*', '+' );
 
 	@Inject
 	DeploymentConfig deploymentConfig;
@@ -114,21 +113,9 @@ public class EditPullRequestBodyAddTaskList {
 	}
 
 	private boolean tasksAreTheSame(String currentTasks, String tasks) {
-		StringBuilder sb = new StringBuilder();
-		for ( char c : tasks.trim().toCharArray() ) {
-			if ( REGEX_ESCAPE_CHARS.contains( c ) ) {
-				sb.append( '\\' );
-			}
-			if ( c == '\n' ) {
-				sb.append( '\\' ).append( 'n' );
-			}
-			else {
-				sb.append( c );
-			}
-		}
 
-		return Patterns.compile( sb.toString().replace( "- \\[ \\]", "- \\[.\\]" ) )
-				.matcher( currentTasks.trim() )
+		return Patterns.compile( Patterns.escapeSpecialCharacters( Patterns.sanitizeNewLines( tasks.trim() ) ).replace( "- \\[ \\]", "- \\[.\\]" ) )
+				.matcher( Patterns.sanitizeNewLines( currentTasks.trim() ) )
 				.matches();
 	}
 

--- a/src/main/java/org/hibernate/infra/bot/util/Patterns.java
+++ b/src/main/java/org/hibernate/infra/bot/util/Patterns.java
@@ -1,11 +1,43 @@
 package org.hibernate.infra.bot.util;
 
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public class Patterns {
+	private static final Set<Character> REGEX_ESCAPE_CHARS = Set.of( '(', ')', '[', ']', '{', '}', '\\', '.', '?', '*', '+' );
 
 	public static Pattern compile(String pattern) {
 		return Pattern.compile(pattern, Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+	}
+
+	/**
+	 * We want to replace any new line character sequences ({@code \n \r \n\r}) with a more predictable one
+	 * which should allow us to use {@link String#contains(CharSequence)} in our text-based checks.
+	 * <p>
+	 * Apparently GitHub body/config files may be returned containing various combinations of these new line character sequences,
+	 * and we may end up failing the checks when we shouldn't.
+	 */
+	public static String sanitizeNewLines(String value) {
+		return value == null ? null : value.replaceAll("\\R", "\n");
+	}
+
+	public static String escapeSpecialCharacters(String value) {
+		if ( value == null ) {
+			return null;
+		}
+		StringBuilder sb = new StringBuilder();
+		for ( char c : value.toCharArray() ) {
+			if ( REGEX_ESCAPE_CHARS.contains( c ) ) {
+				sb.append( '\\' );
+			}
+			if ( c == '\n' ) {
+				sb.append( '\\' ).append( 'n' );
+			}
+			else {
+				sb.append( c );
+			}
+		}
+		return sb.toString();
 	}
 
 	private Patterns() {


### PR DESCRIPTION
 Apparently, GitHub PR body/config files may be returned containing various combinations of these new line character sequences, and we may end up failing the checks when we really shouldn't.