### PR TITLE
Add ignore configuration to the license and task checks

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/EditPullRequestBodyAddTaskList.java
+++ b/src/main/java/org/hibernate/infra/bot/EditPullRequestBodyAddTaskList.java
@@ -27,6 +27,7 @@ import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequest;
 import org.kohsuke.github.GHPullRequestCommitDetail;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHUser;
 
 public class EditPullRequestBodyAddTaskList {
 	private static final Logger LOG = Logger.getLogger( EditPullRequestBodyAddTaskList.class );
@@ -58,7 +59,7 @@ public class EditPullRequestBodyAddTaskList {
 			return;
 		}
 
-		if ( !shouldCheck( repository, pullRequest ) ) {
+		if ( !shouldCheck( repository, pullRequest, repositoryConfig.pullRequestTasks.getIgnore() ) ) {
 			return;
 		}
 
@@ -175,7 +176,15 @@ public class EditPullRequestBodyAddTaskList {
 		}
 	}
 
-	private boolean shouldCheck(GHRepository repository, GHPullRequest pullRequest) {
+	private boolean shouldCheck(GHRepository repository, GHPullRequest pullRequest, List<RepositoryConfig.IgnoreConfiguration> ignoredPRConfigurations) throws IOException {
+		GHUser author = pullRequest.getUser();
+		String title = pullRequest.getTitle();
+		for ( RepositoryConfig.IgnoreConfiguration ignore : ignoredPRConfigurations ) {
+			if ( ignore.getUser().equals( author.getLogin() )
+					&& ignore.getTitlePattern().matcher( title ).matches() ) {
+				return false;
+			}
+		}
 		return !GHIssueState.CLOSED.equals( pullRequest.getState() )
 				&& repository.getId() == pullRequest.getBase().getRepository().getId();
 	}

--- a/src/main/java/org/hibernate/infra/bot/config/RepositoryConfig.java
+++ b/src/main/java/org/hibernate/infra/bot/config/RepositoryConfig.java
@@ -138,6 +138,7 @@ public class RepositoryConfig {
 	public static class LicenseAgreement {
 		private Optional<Boolean> enabled = Optional.empty();
 		private Pattern pullRequestTemplatePattern = Patterns.compile( ".+([-]{22}.+[-]{22}).++" );
+		private List<IgnoreConfiguration> ignore = Collections.emptyList();
 
 		public Optional<Boolean> getEnabled() {
 			return enabled;
@@ -154,12 +155,21 @@ public class RepositoryConfig {
 		public void setPullRequestTemplatePattern(String pullRequestTemplatePattern) {
 			this.pullRequestTemplatePattern = Patterns.compile( pullRequestTemplatePattern );
 		}
+
+		public List<IgnoreConfiguration> getIgnore() {
+			return ignore;
+		}
+
+		public void setIgnore(List<IgnoreConfiguration> ignore) {
+			this.ignore = ignore;
+		}
 	}
 
 	public static class TaskList {
 		private static final String DEFAULT_TASKS_CATEGORY = "default";
 		private Optional<Boolean> enabled = Optional.empty();
 		private Map<String, List<String>> tasks = new HashMap<>();
+		private List<IgnoreConfiguration> ignore = Collections.emptyList();
 
 		public Optional<Boolean> getEnabled() {
 			return enabled;
@@ -179,6 +189,14 @@ public class RepositoryConfig {
 
 		public List<String> defaultTasks() {
 			return tasks.getOrDefault( DEFAULT_TASKS_CATEGORY, List.of() );
+		}
+
+		public List<IgnoreConfiguration> getIgnore() {
+			return ignore;
+		}
+
+		public void setIgnore(List<IgnoreConfiguration> ignore) {
+			this.ignore = ignore;
 		}
 	}
 }


### PR DESCRIPTION
similar to the one we currently have for the Jira check. Dependabot PRs won't have a license agreement, but then they do not need it. Same with the tasks. If we'd need tasks for dependabot PRs the list will be most likely different from the "default" one.