### PR TITLE
Bump quarkus-github-app version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-github-app.version>2.11.0</quarkus-github-app.version>
+    <quarkus-github-app.version>2.12.0</quarkus-github-app.version>
     <quarkus-openapi-generator.version>2.12.1-lts</quarkus-openapi-generator.version>
     <!-- Using a single property for both plugin and platform, so that GitHub's Dependabot doesn't get confused -->
     <quarkus.version>3.28.0</quarkus.version>
@@ -46,7 +46,6 @@
     <quarkus-helm.version>1.2.7</quarkus-helm.version>
     <surefire-plugin.version>3.5.4</surefire-plugin.version>
     <assertj.version>3.27.0</assertj.version>
-    <github-api.version>1.330</github-api.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -64,12 +63,6 @@
       <groupId>io.quarkiverse.githubapp</groupId>
       <artifactId>quarkus-github-app</artifactId>
       <version>${quarkus-github-app.version}</version>
-    </dependency>
-    <!-- Remove management of the github-api dependency when quarkus-github-app ^ is updated to the next version compatible with Quarkus 3.28+ -->
-    <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>github-api</artifactId>
-      <version>${github-api.version}</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>


### PR DESCRIPTION
so that there is no need to manage github-api
and so we don't forget to remove that dependency management when the next Depedabot PRs are opened 🙂 