### PR TITLE
Add check to reject merge commits in pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This includes:
 * Basic formatting of the pull request: at least two words in the title, ...
 * Proper referencing of related JIRA tickets: the ticket key must be mentioned in the PR description.
 * Proper formatting of commits: every commit message must start with the key of a JIRA ticket.
-* Etc.
+* No merge commits: pull requests must not contain merge commits; contributors should rebase on the target branch instead.
 
 ### Jira link insertion
 

--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -220,7 +220,8 @@ public class CheckPullRequestContributionRules {
 						"Offending commits: "
 								+ String.join( ", ", mergeCommitShas.stream().map( sha -> "`" + sha + "`" ).toList() )
 								+ ".\n\nPlease [rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase)"
-								+ " your branch on `" + targetBranch + "` and force-push,"
+								+ " your branch on `" + targetBranch + "` and"
+								+ " [force-push](https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository#about-force-pushing),"
 								+ " rather than merging the target branch into your pull request branch."
 				);
 			}

--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -221,7 +221,7 @@ public class CheckPullRequestContributionRules {
 								+ String.join( ", ", mergeCommitShas.stream().map( sha -> "`" + sha + "`" ).toList() )
 								+ ".\n\nPlease [rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase)"
 								+ " your branch on `" + targetBranch + "` and"
-								+ " [force-push](https://docs.github.com/en/get-started/using-git/pushing-commits-to-a-remote-repository#about-force-pushing),"
+								+ " [force-push](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message#amending-older-or-multiple-commit-messages),"
 								+ " rather than merging the target branch into your pull request branch."
 				);
 			}

--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -217,8 +217,9 @@ public class CheckPullRequestContributionRules {
 			else {
 				String targetBranch = context.pullRequest.getBase().getRef();
 				rule.failed(
-						"Offending commits: " + mergeCommitShas
-								+ ". Please [rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase)"
+						"Offending commits: "
+								+ String.join( ", ", mergeCommitShas.stream().map( sha -> "`" + sha + "`" ).toList() )
+								+ ".\n\nPlease [rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase)"
 								+ " your branch on `" + targetBranch + "` and force-push,"
 								+ " rather than merging the target branch into your pull request branch."
 				);

--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -143,6 +143,7 @@ public class CheckPullRequestContributionRules {
 	private List<PullRequestCheck> createChecks(RepositoryConfig repositoryConfig, String pullRequestTemplate) {
 		List<PullRequestCheck> checks = new ArrayList<>();
 		checks.add( new TitleCheck() );
+		checks.add( new MergeCommitsCheck() );
 
 		if ( repositoryConfig != null && repositoryConfig.jira != null ) {
 			final Integer issueLinksLimit = repositoryConfig.jira.getInsertLinksInPullRequests().isPresent()
@@ -191,6 +192,37 @@ public class CheckPullRequestContributionRules {
 					.result( title != null && SPACE_PATTERN.split( title.trim() ).length >= 2 );
 			output.rule( "The pull request title should not end with an ellipsis (make sure the title is complete)" )
 					.result( title == null || !title.endsWith( "…" ) );
+		}
+	}
+
+	static class MergeCommitsCheck extends PullRequestCheck {
+
+		MergeCommitsCheck() {
+			super( "Contribution — Merge commits" );
+		}
+
+		@Override
+		public void perform(PullRequestCheckRunContext context, PullRequestCheckRunOutput output) throws IOException {
+			List<String> mergeCommitShas = new ArrayList<>();
+			for ( GHPullRequestCommitDetail commitDetail : context.pullRequest.listCommits() ) {
+				if ( commitDetail.getParents().length > 1 ) {
+					mergeCommitShas.add( commitDetail.getSha() );
+				}
+			}
+
+			PullRequestCheckRunRule rule = output.rule( "The pull request should not contain merge commits" );
+			if ( mergeCommitShas.isEmpty() ) {
+				rule.passed();
+			}
+			else {
+				String targetBranch = context.pullRequest.getBase().getRef();
+				rule.failed(
+						"Offending commits: " + mergeCommitShas
+								+ ". Please [rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase)"
+								+ " your branch on `" + targetBranch + "` and force-push,"
+								+ " rather than merging the target branch into your pull request branch."
+				);
+			}
 		}
 	}
 

--- a/src/test/java/org/hibernate/infra/bot/tests/AbstractPullRequestTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/AbstractPullRequestTest.java
@@ -14,6 +14,8 @@ import org.mockito.Answers;
 abstract class AbstractPullRequestTest {
 	final GHCheckRunBuilder titleCheckRunCreateBuilderMock = mockCheckRunBuilder();
 	final GHCheckRunBuilder titleCheckRunUpdateBuilderMock = mockCheckRunBuilder();
+	final GHCheckRunBuilder mergeCommitsCheckRunCreateBuilderMock = mockCheckRunBuilder();
+	final GHCheckRunBuilder mergeCommitsCheckRunUpdateBuilderMock = mockCheckRunBuilder();
 	final GHCheckRunBuilder jiraCheckRunCreateBuilderMock = mockCheckRunBuilder();
 	final GHCheckRunBuilder jiraCheckRunUpdateBuilderMock = mockCheckRunBuilder();
 
@@ -27,6 +29,12 @@ abstract class AbstractPullRequestTest {
 				titleCheckRunCreateBuilderMock, titleCheckRunMock, 42L
 		);
 		mockUpdateCheckRun( repoMock, 42L, titleCheckRunUpdateBuilderMock, titleCheckRunMock );
+
+		GHCheckRun mergeCommitsCheckRunMock = mock( GHCheckRun.class );
+		mockCreateCheckRun( repoMock, "Contribution — Merge commits", headSHA,
+				mergeCommitsCheckRunCreateBuilderMock, mergeCommitsCheckRunMock, 46L
+		);
+		mockUpdateCheckRun( repoMock, 46L, mergeCommitsCheckRunUpdateBuilderMock, mergeCommitsCheckRunMock );
 
 		GHCheckRun jiraCheckRunMock = mock( GHCheckRun.class );
 		mockCreateCheckRun( repoMock, "Contribution — JIRA issues", headSHA,

--- a/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesJiraTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesJiraTest.java
@@ -246,6 +246,7 @@ public class CheckPullRequestContributionRulesJiraTest extends AbstractPullReque
 				.event( GHEvent.PULL_REQUEST, true )
 				.then()
 				.github( mocks -> {
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.FAILURE );
 					verify( jiraCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.FAILURE );
 
 					var outputCaptor = ArgumentCaptor.forClass( GHCheckRunBuilder.Output.class );
@@ -264,12 +265,14 @@ public class CheckPullRequestContributionRulesJiraTest extends AbstractPullReque
 					assertThat( messageCaptor.getValue() )
 							.isEqualTo( """
 									Thanks for your pull request!
-									
+
 									This pull request does not follow the contribution rules. Could you have a look?
-									
+
+									❌ Contribution — Merge commits
+									    ↳ Failed with exception java.lang.IllegalStateException: Simulated failure
 									❌ Contribution — JIRA issues
 									    ↳ Failed with exception java.lang.IllegalStateException: Simulated failure
-									
+
 									› This message was automatically generated.""" );
 					verifyNoMoreInteractions( mocks.ghObjects() );
 				} );

--- a/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesMergeCommitsTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesMergeCommitsTest.java
@@ -1,0 +1,130 @@
+package org.hibernate.infra.bot.tests;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.kohsuke.github.GHCheckRun;
+import org.kohsuke.github.GHCheckRunBuilder;
+import org.kohsuke.github.GHEvent;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@QuarkusTest
+@GitHubAppTest
+@ExtendWith(MockitoExtension.class)
+public class CheckPullRequestContributionRulesMergeCommitsTest extends AbstractPullRequestTest {
+	@Test
+	void noMergeCommits() throws IOException {
+		long repoId = 344815557L;
+		long prId = 585627026L;
+		given()
+				.github( mocks -> {
+					mocks.configFile("hibernate-github-bot.yml")
+							.fromString( """
+									jira:
+									  projectKey: "HSEARCH"
+									""" );
+
+					GHRepository repoMock = mocks.repository( "yrodiere/hibernate-github-bot-playground" );
+					when( repoMock.getId() ).thenReturn( repoId );
+
+					PullRequestMockHelper.start( mocks, prId, repoMock )
+							.commit( "HSEARCH-1111 Correct message" )
+							.comment( "Some comment" )
+							.comment( "Some other comment" );
+
+					mockCheckRuns( repoMock, "6e9f11a1e2946b207c6eb245ec942f2b5a3ea156" );
+				} )
+				.when()
+				.payloadFromClasspath( "/pullrequest-opened-hsearch-1111.json" )
+				.event( GHEvent.PULL_REQUEST )
+				.then()
+				.github( mocks -> {
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.SUCCESS );
+
+					var outputCaptor = ArgumentCaptor.forClass( GHCheckRunBuilder.Output.class );
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).add( outputCaptor.capture() );
+					var output = outputCaptor.getValue();
+					assertThat( output )
+							.extracting( "title", InstanceOfAssertFactories.STRING )
+							.contains( "All rules passed" );
+
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+
+	@Test
+	void hasMergeCommits() throws IOException {
+		long repoId = 344815557L;
+		long prId = 585627026L;
+		given()
+				.github( mocks -> {
+					mocks.configFile("hibernate-github-bot.yml")
+							.fromString( """
+									jira:
+									  projectKey: "HSEARCH"
+									""" );
+
+					GHRepository repoMock = mocks.repository( "yrodiere/hibernate-github-bot-playground" );
+					when( repoMock.getId() ).thenReturn( repoId );
+
+					PullRequestMockHelper.start( mocks, prId, repoMock )
+							.baseRef( "main" )
+							.commit( "HSEARCH-1111 Some work" )
+							.mergeCommit( "HSEARCH-1111 Merge branch 'main' into feature", "abc123def456" )
+							.comment( "Some comment" )
+							.comment( "Some other comment" );
+
+					mockCheckRuns( repoMock, "6e9f11a1e2946b207c6eb245ec942f2b5a3ea156" );
+				} )
+				.when()
+				.payloadFromClasspath( "/pullrequest-opened-hsearch-1111.json" )
+				.event( GHEvent.PULL_REQUEST )
+				.then()
+				.github( mocks -> {
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.FAILURE );
+
+					var outputCaptor = ArgumentCaptor.forClass( GHCheckRunBuilder.Output.class );
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).add( outputCaptor.capture() );
+					var output = outputCaptor.getValue();
+					assertThat( output )
+							.extracting( "title", InstanceOfAssertFactories.STRING )
+							.isEqualTo( "The pull request should not contain merge commits" );
+					assertThat( output )
+							.extracting( "summary", InstanceOfAssertFactories.STRING )
+							.contains(
+									"The pull request should not contain merge commits",
+									"abc123def456",
+									"rebase",
+									"`main`",
+									"https://docs.github.com/en/get-started/using-git/about-git-rebase"
+							);
+
+					GHPullRequest prMock = mocks.pullRequest( prId );
+					ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass( String.class );
+					verify( prMock ).comment( messageCaptor.capture() );
+					assertThat( messageCaptor.getValue() )
+							.contains(
+									"The pull request should not contain merge commits",
+									"abc123def456",
+									"rebase",
+									"`main`",
+									"https://docs.github.com/en/get-started/using-git/about-git-rebase"
+							);
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+}

--- a/src/test/java/org/hibernate/infra/bot/tests/PullRequestMockHelper.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/PullRequestMockHelper.java
@@ -26,18 +26,28 @@ public class PullRequestMockHelper {
 		GHCommitPointer baseMock = stub( GHCommitPointer.class );
 		when( pullRequestMock.getBase() ).thenReturn( baseMock );
 		when( baseMock.getRepository() ).thenReturn( repoMock );
-		return new PullRequestMockHelper( repoMock, pullRequestMock );
+		return new PullRequestMockHelper( repoMock, pullRequestMock, baseMock );
 	}
 
 	private final GHRepository repoMock;
 	private final GHPullRequest pullRequestMock;
+	private final GHCommitPointer baseMock;
 
 	private List<GHIssueComment> commentsMocks;
-	private List<GHPullRequestCommitDetail> commitDetailsMocks;
+	private final List<GHPullRequestCommitDetail> commitDetailsMocks;
 
-	private PullRequestMockHelper(GHRepository repoMock, GHPullRequest pullRequestMock) {
+	private PullRequestMockHelper(GHRepository repoMock, GHPullRequest pullRequestMock, GHCommitPointer baseMock) {
 		this.repoMock = repoMock;
 		this.pullRequestMock = pullRequestMock;
+		this.baseMock = baseMock;
+		this.commitDetailsMocks = new ArrayList<>();
+		PagedIterable<GHPullRequestCommitDetail> commitIterableMock = mockPagedIterable( commitDetailsMocks );
+		when( pullRequestMock.listCommits() ).thenReturn( commitIterableMock );
+	}
+
+	public PullRequestMockHelper baseRef(String ref) {
+		when( baseMock.getRef() ).thenReturn( ref );
+		return this;
 	}
 
 	public PullRequestMockHelper commit(String message) throws IOException {
@@ -49,16 +59,14 @@ public class PullRequestMockHelper {
 	}
 
 	public PullRequestMockHelper commit(String message, String sha, List<String> files) throws IOException {
-		if ( commitDetailsMocks == null ) {
-			commitDetailsMocks = new ArrayList<>();
-			PagedIterable<GHPullRequestCommitDetail> commitIterableMock = mockPagedIterable( commitDetailsMocks );
-			when( pullRequestMock.listCommits() ).thenReturn( commitIterableMock );
-		}
 		GHPullRequestCommitDetail commitDetailMock = stub( GHPullRequestCommitDetail.class );
 		commitDetailsMocks.add( commitDetailMock );
 		GHPullRequestCommitDetail.Commit commitMock = stub( GHPullRequestCommitDetail.Commit.class );
 		when( commitDetailMock.getCommit() ).thenReturn( commitMock );
 		when( commitMock.getMessage() ).thenReturn( message );
+		GHPullRequestCommitDetail.CommitPointer parentMock = stub( GHPullRequestCommitDetail.CommitPointer.class );
+		when( commitDetailMock.getParents() )
+				.thenReturn( new GHPullRequestCommitDetail.CommitPointer[] { parentMock } );
 		if ( sha != null ) {
 			when( commitDetailMock.getSha() ).thenReturn( sha );
 		}
@@ -74,6 +82,22 @@ public class PullRequestMockHelper {
 				when( stub.getFileName() ).thenReturn( file );
 				ghFiles.add( stub );
 			}
+		}
+		return this;
+	}
+
+	public PullRequestMockHelper mergeCommit(String message, String sha) {
+		GHPullRequestCommitDetail commitDetailMock = stub( GHPullRequestCommitDetail.class );
+		commitDetailsMocks.add( commitDetailMock );
+		GHPullRequestCommitDetail.Commit commitMock = stub( GHPullRequestCommitDetail.Commit.class );
+		when( commitDetailMock.getCommit() ).thenReturn( commitMock );
+		when( commitMock.getMessage() ).thenReturn( message );
+		GHPullRequestCommitDetail.CommitPointer parentMock1 = stub( GHPullRequestCommitDetail.CommitPointer.class );
+		GHPullRequestCommitDetail.CommitPointer parentMock2 = stub( GHPullRequestCommitDetail.CommitPointer.class );
+		when( commitDetailMock.getParents() )
+				.thenReturn( new GHPullRequestCommitDetail.CommitPointer[] { parentMock1, parentMock2 } );
+		if ( sha != null ) {
+			when( commitDetailMock.getSha() ).thenReturn( sha );
 		}
 		return this;
 	}


### PR DESCRIPTION
## Summary

- Add a `MergeCommitsCheck` that detects merge commits (commits with more than one parent) in pull requests, inspired by the similar feature in [quarkus-github-bot](https://github.com/quarkusio/quarkus-github-bot/blob/main/src/main/java/io/quarkus/bot/CheckPullRequestContributionRules.java).
- When merge commits are found, the check fails with a message that lists the offending commit SHAs, suggests rebasing on the target branch (mentioned by name), and links to the [GitHub docs on rebasing](https://docs.github.com/en/get-started/using-git/about-git-rebase).
- The check is always enabled (like `TitleCheck`), requires no per-repository configuration, and integrates into the existing check infrastructure as a `PullRequestCheck`.

## Changes

- **`CheckPullRequestContributionRules.java`**: Added `MergeCommitsCheck` inner class and registered it in `createChecks()`.
- **`PullRequestMockHelper.java`**: Initialize `listCommits()` with an empty iterable by default (instead of lazily); added `mergeCommit()` method to create commits with 2 parents; added `baseRef()` method to stub the PR base branch ref; set a default single parent on regular commits.
- **`AbstractPullRequestTest.java`**: Added mock fields and setup for the new "Contribution — Merge commits" check run.
- **`CheckPullRequestContributionRulesMergeCommitsTest.java`** (new): Tests for both the passing case (no merge commits) and the failing case (with merge commits).
- **`CheckPullRequestContributionRulesJiraTest.java`**: Updated the `listCommits()` failure test to also expect the merge commits check failure.

## Test plan

- [x] All 42 existing + new tests pass (`mvn test`)
- [ ] Deploy to a test environment and verify the check appears on a PR with merge commits
- [ ] Verify the error message correctly names the target branch and links to GitHub docs