### PR TITLE
Trigger Develocity report on workflow_run completion

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/ExtractDevelocityBuildScans.java
+++ b/src/main/java/org/hibernate/infra/bot/ExtractDevelocityBuildScans.java
@@ -28,6 +28,7 @@ import com.gradle.develocity.model.BuildsQuery;
 
 import io.quarkiverse.githubapp.ConfigFile;
 import io.quarkiverse.githubapp.event.CheckRun;
+import io.quarkiverse.githubapp.event.WorkflowRun;
 import io.quarkus.logging.Log;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -57,6 +58,22 @@ public class ExtractDevelocityBuildScans {
 		}
 		String sha = checkRun.getHeadSha();
 		extractCIBuildScans( repository, repositoryConfig.develocity.buildScan, sha );
+	}
+
+	void workflowRunCompleted(@WorkflowRun.Completed GHEventPayload.WorkflowRun payload,
+			@ConfigFile("hibernate-github-bot.yml") RepositoryConfig repositoryConfig) {
+		if ( repositoryConfig == null
+				|| repositoryConfig.develocity == null
+				|| repositoryConfig.develocity.buildScan == null ) {
+			return;
+		}
+		var buildScanConfig = repositoryConfig.develocity.buildScan;
+		if ( !buildScanConfig.addCheck ) {
+			return;
+		}
+		var repository = payload.getRepository();
+		var sha = payload.getWorkflowRun().getHeadSha();
+		extractCIBuildScans( repository, buildScanConfig, sha );
 	}
 
 	void checkRunCompleted(@CheckRun.Completed GHEventPayload.CheckRun payload,

--- a/src/test/java/org/hibernate/infra/bot/tests/ExtractDevelocityBuildScansTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/ExtractDevelocityBuildScansTest.java
@@ -1,6 +1,7 @@
 package org.hibernate.infra.bot.tests;
 
 import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.gradle.develocity.api.BuildsApi;
+import com.gradle.develocity.model.BuildsQuery;
 
 import io.quarkiverse.githubapp.testing.GitHubAppTest;
 import io.quarkus.test.InjectMock;
@@ -30,6 +32,7 @@ import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.PagedIterable;
 import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @QuarkusTest
@@ -77,7 +80,12 @@ public class ExtractDevelocityBuildScansTest {
 					GHRepository repoMock = mocks.repository( REPO_NAME );
 					verify( repoMock ).createCheckRun( "Develocity Build Scans", HEAD_SHA );
 					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
-					verify( develocityBuildsApiMock ).getBuilds( any() );
+					var queryCaptor = ArgumentCaptor.forClass( BuildsQuery.BuildsQueryQueryParam.class );
+					verify( develocityBuildsApiMock ).getBuilds( queryCaptor.capture() );
+					String query = queryCaptor.getValue().getQuery();
+					assertThat( query )
+							.contains( "value:\"Git commit id=" + HEAD_SHA + "\"" )
+							.contains( "value:\"CI run=27276276443\"" );
 				} );
 	}
 
@@ -102,7 +110,13 @@ public class ExtractDevelocityBuildScansTest {
 					GHRepository repoMock = mocks.repository( REPO_NAME );
 					verify( repoMock ).createCheckRun( "Develocity Build Scans", HEAD_SHA );
 					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
-					verify( develocityBuildsApiMock ).getBuilds( any() );
+					var queryCaptor = ArgumentCaptor.forClass( BuildsQuery.BuildsQueryQueryParam.class );
+					verify( develocityBuildsApiMock ).getBuilds( queryCaptor.capture() );
+					String query = queryCaptor.getValue().getQuery();
+					assertThat( query )
+							.contains( "value:\"Git commit id=" + HEAD_SHA + "\"" )
+							.contains( "value:\"CI job=hibernate-orm-pipeline\"" )
+							.contains( "value:\"CI build number=1234\"" );
 				} );
 	}
 
@@ -187,7 +201,11 @@ public class ExtractDevelocityBuildScansTest {
 					GHRepository repoMock = mocks.repository( REPO_NAME );
 					verify( repoMock ).createCheckRun( "Develocity Build Scans", WORKFLOW_HEAD_SHA );
 					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
-					verify( develocityBuildsApiMock ).getBuilds( any() );
+					var queryCaptor = ArgumentCaptor.forClass( BuildsQuery.BuildsQueryQueryParam.class );
+					verify( develocityBuildsApiMock ).getBuilds( queryCaptor.capture() );
+					String query = queryCaptor.getValue().getQuery();
+					assertThat( query )
+							.contains( "value:\"Git commit id=" + WORKFLOW_HEAD_SHA + "\"" );
 				} );
 	}
 

--- a/src/test/java/org/hibernate/infra/bot/tests/ExtractDevelocityBuildScansTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/ExtractDevelocityBuildScansTest.java
@@ -1,0 +1,235 @@
+package org.hibernate.infra.bot.tests;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.gradle.develocity.api.BuildsApi;
+
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.kohsuke.github.GHApp;
+import org.kohsuke.github.GHCheckRun;
+import org.kohsuke.github.GHCheckRunBuilder;
+import org.kohsuke.github.GHEvent;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedIterable;
+import org.mockito.Answers;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@QuarkusTest
+@GitHubAppTest
+@ExtendWith(MockitoExtension.class)
+public class ExtractDevelocityBuildScansTest {
+
+	private static final String HEAD_SHA = "f280d7c37ff6828f4f0c07f6635c235a243d54d9";
+	private static final String WORKFLOW_HEAD_SHA = "ddbf12d7d8ff89a85c579c98c75358d8e9015cc5";
+	private static final String REPO_NAME = "hibernate/hibernate-orm";
+	private static final long DEVELOCITY_CHECK_RUN_ID = 999L;
+	private static final String DEVELOCITY_BUILD_SCAN_CONFIG = """
+			develocity:
+			  buildScan:
+			    addCheck: true
+			""";
+
+	@InjectMock
+	@RestClient
+	BuildsApi develocityBuildsApiMock;
+
+	@BeforeEach
+	void setUp() {
+		when( develocityBuildsApiMock.getBuilds( any() ) ).thenReturn( Collections.emptyList() );
+	}
+
+	@Test
+	void checkRunCompleted_githubActions() throws IOException {
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( DEVELOCITY_BUILD_SCAN_CONFIG );
+
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+
+					mockGetCheckRuns( repoMock, HEAD_SHA,
+							mockGitHubActionsCheckRun( HEAD_SHA ) );
+					mockDevelocityCheckRun( repoMock, HEAD_SHA );
+				} )
+				.when()
+				.payloadFromClasspath( "/check-run-completed-github-actions.json" )
+				.event( GHEvent.CHECK_RUN )
+				.then()
+				.github( mocks -> {
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+					verify( repoMock ).createCheckRun( "Develocity Build Scans", HEAD_SHA );
+					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
+					verify( develocityBuildsApiMock ).getBuilds( any() );
+				} );
+	}
+
+	@Test
+	void checkRunCompleted_jenkins() throws IOException {
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( DEVELOCITY_BUILD_SCAN_CONFIG );
+
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+
+					mockGetCheckRuns( repoMock, HEAD_SHA,
+							mockJenkinsCheckRun( HEAD_SHA ) );
+					mockDevelocityCheckRun( repoMock, HEAD_SHA );
+				} )
+				.when()
+				.payloadFromClasspath( "/check-run-completed-jenkins.json" )
+				.event( GHEvent.CHECK_RUN )
+				.then()
+				.github( mocks -> {
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+					verify( repoMock ).createCheckRun( "Develocity Build Scans", HEAD_SHA );
+					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
+					verify( develocityBuildsApiMock ).getBuilds( any() );
+				} );
+	}
+
+	@Test
+	void checkRunCompleted_noConfig() throws IOException {
+		given()
+				.github( mocks -> {
+				} )
+				.when()
+				.payloadFromClasspath( "/check-run-completed-github-actions.json" )
+				.event( GHEvent.CHECK_RUN )
+				.then()
+				.github( mocks -> {
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+
+	@Test
+	void checkRunCompleted_ownCheckRun() throws IOException {
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( DEVELOCITY_BUILD_SCAN_CONFIG );
+				} )
+				.when()
+				.payloadFromString( """
+						{
+						  "action": "completed",
+						  "check_run": {
+						    "id": 80558394108,
+						    "name": "Develocity Build Scans",
+						    "head_sha": "%s",
+						    "external_id": "",
+						    "status": "completed",
+						    "conclusion": "neutral",
+						    "app": {
+						      "id": 15368,
+						      "slug": "github-actions"
+						    },
+						    "pull_requests": []
+						  },
+						  "repository": {
+						    "id": 961036,
+						    "name": "hibernate-orm",
+						    "full_name": "%s",
+						    "private": false,
+						    "owner": {
+						      "login": "hibernate",
+						      "id": 348262
+						    }
+						  },
+						  "installation": {
+						    "id": 15390286
+						  }
+						}
+						""".formatted( HEAD_SHA, REPO_NAME ) )
+				.event( GHEvent.CHECK_RUN )
+				.then()
+				.github( mocks -> {
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+
+	@Test
+	void workflowRunCompleted() throws IOException {
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( DEVELOCITY_BUILD_SCAN_CONFIG );
+
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+
+					mockGetCheckRuns( repoMock, WORKFLOW_HEAD_SHA,
+							mockGitHubActionsCheckRun( WORKFLOW_HEAD_SHA ) );
+					mockDevelocityCheckRun( repoMock, WORKFLOW_HEAD_SHA );
+				} )
+				.when()
+				.payloadFromClasspath( "/workflow-run-completed.json" )
+				.event( GHEvent.WORKFLOW_RUN )
+				.then()
+				.github( mocks -> {
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+					verify( repoMock ).createCheckRun( "Develocity Build Scans", WORKFLOW_HEAD_SHA );
+					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
+					verify( develocityBuildsApiMock ).getBuilds( any() );
+				} );
+	}
+
+	private GHCheckRun mockGitHubActionsCheckRun(String sha) throws IOException {
+		GHCheckRun checkRun = mock( GHCheckRun.class );
+		GHApp app = mock( GHApp.class );
+		when( checkRun.getApp() ).thenReturn( app );
+		when( app.getSlug() ).thenReturn( "github-actions" );
+		when( checkRun.getHeadSha() ).thenReturn( sha );
+		when( checkRun.getDetailsUrl() ).thenReturn(
+				new URL( "https://github.com/hibernate/hibernate-orm/actions/runs/27276276443/job/80558394108" ) );
+		return checkRun;
+	}
+
+	private GHCheckRun mockJenkinsCheckRun(String sha) {
+		GHCheckRun checkRun = mock( GHCheckRun.class );
+		GHApp app = mock( GHApp.class );
+		when( checkRun.getApp() ).thenReturn( app );
+		when( app.getId() ).thenReturn( 347853L );
+		when( checkRun.getHeadSha() ).thenReturn( sha );
+		when( checkRun.getExternalId() ).thenReturn( "hibernate-orm-pipeline#1234" );
+		return checkRun;
+	}
+
+	@SuppressWarnings("unchecked")
+	private void mockGetCheckRuns(GHRepository repoMock, String sha, GHCheckRun... checkRuns) throws IOException {
+		PagedIterable<GHCheckRun> iterable = mock( PagedIterable.class );
+		when( repoMock.getCheckRuns( sha ) ).thenReturn( iterable );
+		when( iterable.toList() ).thenReturn( List.of( checkRuns ) );
+	}
+
+	private void mockDevelocityCheckRun(GHRepository repoMock, String sha) throws IOException {
+		GHCheckRunBuilder createBuilder = mock( GHCheckRunBuilder.class,
+				withSettings().defaultAnswer( Answers.RETURNS_SELF ) );
+		when( repoMock.createCheckRun( "Develocity Build Scans", sha ) ).thenReturn( createBuilder );
+		GHCheckRun checkRunMock = mock( GHCheckRun.class );
+		when( checkRunMock.getId() ).thenReturn( DEVELOCITY_CHECK_RUN_ID );
+		when( createBuilder.create() ).thenReturn( checkRunMock );
+
+		GHCheckRunBuilder updateBuilder = mock( GHCheckRunBuilder.class,
+				withSettings().defaultAnswer( Answers.RETURNS_SELF ) );
+		when( repoMock.updateCheckRun( DEVELOCITY_CHECK_RUN_ID ) ).thenReturn( updateBuilder );
+		when( updateBuilder.create() ).thenReturn( checkRunMock );
+	}
+}

--- a/src/test/resources/check-run-completed-github-actions.json
+++ b/src/test/resources/check-run-completed-github-actions.json
@@ -1,0 +1,119 @@
+{
+  "action": "completed",
+  "check_run": {
+    "id": 80558394108,
+    "name": "OpenJDK 25 - spanner",
+    "node_id": "CR_kwDOAA6qDM8AAAASwaeK_A",
+    "head_sha": "f280d7c37ff6828f4f0c07f6635c235a243d54d9",
+    "external_id": "484a693d-9d4e-5c4f-8b29-e7192bf64705",
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm/check-runs/80558394108",
+    "html_url": "https://github.com/hibernate/hibernate-orm/actions/runs/27276276443/job/80558394108",
+    "details_url": "https://github.com/hibernate/hibernate-orm/actions/runs/27276276443/job/80558394108",
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2026-06-10T12:29:49Z",
+    "completed_at": "2026-06-10T13:04:47Z",
+    "output": {
+      "title": null,
+      "summary": null,
+      "text": null,
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/hibernate/hibernate-orm/check-runs/80558394108/annotations"
+    },
+    "check_suite": {
+      "id": 73312401811,
+      "node_id": "CS_kwDOAA6qDM8AAAAREcJ5kw",
+      "head_branch": "nullaway",
+      "head_sha": "f280d7c37ff6828f4f0c07f6635c235a243d54d9",
+      "status": "in_progress",
+      "conclusion": null,
+      "url": "https://api.github.com/repos/hibernate/hibernate-orm/check-suites/73312401811",
+      "before": null,
+      "after": null,
+      "pull_requests": [],
+      "app": {
+        "id": 15368,
+        "client_id": "Iv1.05c79e9ad1f6bdfa",
+        "slug": "github-actions",
+        "node_id": "MDM6QXBwMTUzNjg=",
+        "owner": {
+          "login": "github",
+          "id": 9919,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+          "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/github",
+          "html_url": "https://github.com/github",
+          "type": "Organization",
+          "site_admin": false
+        },
+        "name": "GitHub Actions",
+        "description": "Automate your workflow from idea to production",
+        "external_url": "https://help.github.com/en/actions",
+        "html_url": "https://github.com/apps/github-actions",
+        "created_at": "2018-07-30T09:30:17Z",
+        "updated_at": "2026-05-05T14:51:38Z"
+      },
+      "created_at": "2026-06-10T12:29:25Z",
+      "updated_at": "2026-06-10T12:29:50Z"
+    },
+    "app": {
+      "id": 15368,
+      "client_id": "Iv1.05c79e9ad1f6bdfa",
+      "slug": "github-actions",
+      "node_id": "MDM6QXBwMTUzNjg=",
+      "owner": {
+        "login": "github",
+        "id": 9919,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjk5MTk=",
+        "avatar_url": "https://avatars.githubusercontent.com/u/9919?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/github",
+        "html_url": "https://github.com/github",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "GitHub Actions",
+      "description": "Automate your workflow from idea to production",
+      "external_url": "https://help.github.com/en/actions",
+      "html_url": "https://github.com/apps/github-actions",
+      "created_at": "2018-07-30T09:30:17Z",
+      "updated_at": "2026-05-05T14:51:38Z"
+    },
+    "pull_requests": []
+  },
+  "repository": {
+    "id": 961036,
+    "node_id": "MDEwOlJlcG9zaXRvcnk5NjEwMzY=",
+    "name": "hibernate-orm",
+    "full_name": "hibernate/hibernate-orm",
+    "private": false,
+    "owner": {
+      "login": "hibernate",
+      "id": 348262,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjM0ODI2Mg==",
+      "avatar_url": "https://avatars.githubusercontent.com/u/348262?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/hibernate",
+      "html_url": "https://github.com/hibernate",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/hibernate/hibernate-orm",
+    "description": "Idiomatic persistence for Java and relational databases",
+    "fork": false,
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm"
+  },
+  "organization": {
+    "login": "hibernate",
+    "id": 348262
+  },
+  "sender": {
+    "login": "yrodiere",
+    "id": 412878
+  },
+  "installation": {
+    "id": 15390286,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMTUzOTAyODY="
+  }
+}

--- a/src/test/resources/check-run-completed-jenkins.json
+++ b/src/test/resources/check-run-completed-jenkins.json
@@ -1,0 +1,117 @@
+{
+  "action": "completed",
+  "check_run": {
+    "id": 80558394200,
+    "name": "hibernate-orm-pipeline",
+    "node_id": "CR_kwDOAA6qDM8AAAASwaeK_B",
+    "head_sha": "f280d7c37ff6828f4f0c07f6635c235a243d54d9",
+    "external_id": "hibernate-orm-pipeline#1234",
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm/check-runs/80558394200",
+    "html_url": "https://ci.hibernate.org/job/hibernate-orm-pipeline/1234/",
+    "details_url": "https://ci.hibernate.org/job/hibernate-orm-pipeline/1234/",
+    "status": "completed",
+    "conclusion": "success",
+    "started_at": "2026-06-10T12:29:49Z",
+    "completed_at": "2026-06-10T13:04:47Z",
+    "output": {
+      "title": null,
+      "summary": null,
+      "text": null,
+      "annotations_count": 0,
+      "annotations_url": "https://api.github.com/repos/hibernate/hibernate-orm/check-runs/80558394200/annotations"
+    },
+    "check_suite": {
+      "id": 73312401812,
+      "node_id": "CS_kwDOAA6qDM8AAAAREcJ5lA",
+      "head_branch": "main",
+      "head_sha": "f280d7c37ff6828f4f0c07f6635c235a243d54d9",
+      "status": "completed",
+      "conclusion": "success",
+      "url": "https://api.github.com/repos/hibernate/hibernate-orm/check-suites/73312401812",
+      "before": null,
+      "after": null,
+      "pull_requests": [],
+      "app": {
+        "id": 347853,
+        "slug": "hibernate-ci",
+        "node_id": "MDM6QXBwMzQ3ODUz",
+        "owner": {
+          "login": "hibernate",
+          "id": 348262,
+          "node_id": "MDEyOk9yZ2FuaXphdGlvbjM0ODI2Mg==",
+          "avatar_url": "https://avatars.githubusercontent.com/u/348262?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/hibernate",
+          "html_url": "https://github.com/hibernate",
+          "type": "Organization",
+          "site_admin": false
+        },
+        "name": "Hibernate CI",
+        "description": "Jenkins CI for Hibernate projects",
+        "external_url": "https://ci.hibernate.org",
+        "html_url": "https://github.com/apps/hibernate-ci",
+        "created_at": "2022-09-01T10:00:00Z",
+        "updated_at": "2026-01-01T10:00:00Z"
+      },
+      "created_at": "2026-06-10T12:29:25Z",
+      "updated_at": "2026-06-10T13:04:47Z"
+    },
+    "app": {
+      "id": 347853,
+      "slug": "hibernate-ci",
+      "node_id": "MDM6QXBwMzQ3ODUz",
+      "owner": {
+        "login": "hibernate",
+        "id": 348262,
+        "node_id": "MDEyOk9yZ2FuaXphdGlvbjM0ODI2Mg==",
+        "avatar_url": "https://avatars.githubusercontent.com/u/348262?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/hibernate",
+        "html_url": "https://github.com/hibernate",
+        "type": "Organization",
+        "site_admin": false
+      },
+      "name": "Hibernate CI",
+      "description": "Jenkins CI for Hibernate projects",
+      "external_url": "https://ci.hibernate.org",
+      "html_url": "https://github.com/apps/hibernate-ci",
+      "created_at": "2022-09-01T10:00:00Z",
+      "updated_at": "2026-01-01T10:00:00Z"
+    },
+    "pull_requests": []
+  },
+  "repository": {
+    "id": 961036,
+    "node_id": "MDEwOlJlcG9zaXRvcnk5NjEwMzY=",
+    "name": "hibernate-orm",
+    "full_name": "hibernate/hibernate-orm",
+    "private": false,
+    "owner": {
+      "login": "hibernate",
+      "id": 348262,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjM0ODI2Mg==",
+      "avatar_url": "https://avatars.githubusercontent.com/u/348262?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/hibernate",
+      "html_url": "https://github.com/hibernate",
+      "type": "Organization",
+      "site_admin": false
+    },
+    "html_url": "https://github.com/hibernate/hibernate-orm",
+    "description": "Idiomatic persistence for Java and relational databases",
+    "fork": false,
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm"
+  },
+  "organization": {
+    "login": "hibernate",
+    "id": 348262
+  },
+  "sender": {
+    "login": "yrodiere",
+    "id": 412878
+  },
+  "installation": {
+    "id": 15390286,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMTUzOTAyODY="
+  }
+}

--- a/src/test/resources/workflow-run-completed.json
+++ b/src/test/resources/workflow-run-completed.json
@@ -1,0 +1,131 @@
+{
+  "action": "completed",
+  "workflow_run": {
+    "id": 14112498346,
+    "name": "GH Actions CI reporting",
+    "node_id": "WFR_kwLOAA6qDM8AAAADSSuiqg",
+    "head_branch": "main",
+    "head_sha": "ddbf12d7d8ff89a85c579c98c75358d8e9015cc5",
+    "path": ".github/workflows/ci-report.yml",
+    "display_title": "GH Actions CI reporting",
+    "run_number": 2347,
+    "event": "workflow_run",
+    "status": "completed",
+    "conclusion": "success",
+    "workflow_id": 124546728,
+    "check_suite_id": 36324304144,
+    "check_suite_node_id": "CS_kwDOAA6qDM8AAAAIdRjlEA",
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/runs/14112498346",
+    "html_url": "https://github.com/hibernate/hibernate-orm/actions/runs/14112498346",
+    "pull_requests": [],
+    "created_at": "2025-03-27T17:05:01Z",
+    "updated_at": "2025-03-27T17:19:44Z",
+    "actor": {
+      "login": "mbladel",
+      "id": 25681369
+    },
+    "run_attempt": 2,
+    "referenced_workflows": [],
+    "run_started_at": "2025-03-27T17:17:28Z",
+    "triggering_actor": {
+      "login": "beikov",
+      "id": 358916
+    },
+    "jobs_url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/runs/14112498346/jobs",
+    "logs_url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/runs/14112498346/logs",
+    "check_suite_url": "https://api.github.com/repos/hibernate/hibernate-orm/check-suites/36324304144",
+    "artifacts_url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/runs/14112498346/artifacts",
+    "cancel_url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/runs/14112498346/cancel",
+    "rerun_url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/runs/14112498346/rerun",
+    "workflow_url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/workflows/124546728",
+    "head_commit": {
+      "id": "ddbf12d7d8ff89a85c579c98c75358d8e9015cc5",
+      "tree_id": "53c527f52ec4f6632e7db86b9863b3c6ef709a3d",
+      "message": "HIB-140 Switch to access keys for develocity.commonhaus.dev",
+      "timestamp": "2025-03-27T16:54:54Z",
+      "author": {
+        "name": "Christian Beikov",
+        "email": "christian.beikov@gmail.com"
+      },
+      "committer": {
+        "name": "Christian Beikov",
+        "email": "christian.beikov@gmail.com"
+      }
+    },
+    "repository": {
+      "id": 961036,
+      "node_id": "MDEwOlJlcG9zaXRvcnk5NjEwMzY=",
+      "name": "hibernate-orm",
+      "full_name": "hibernate/hibernate-orm",
+      "private": false,
+      "owner": {
+        "login": "hibernate",
+        "id": 348262
+      },
+      "html_url": "https://github.com/hibernate/hibernate-orm",
+      "description": "Hibernate's core Object/Relational Mapping functionality",
+      "fork": false,
+      "url": "https://api.github.com/repos/hibernate/hibernate-orm"
+    },
+    "head_repository": {
+      "id": 961036,
+      "node_id": "MDEwOlJlcG9zaXRvcnk5NjEwMzY=",
+      "name": "hibernate-orm",
+      "full_name": "hibernate/hibernate-orm",
+      "private": false,
+      "owner": {
+        "login": "hibernate",
+        "id": 348262
+      },
+      "html_url": "https://github.com/hibernate/hibernate-orm",
+      "description": "Hibernate's core Object/Relational Mapping functionality",
+      "fork": false,
+      "url": "https://api.github.com/repos/hibernate/hibernate-orm"
+    }
+  },
+  "workflow": {
+    "id": 124546728,
+    "node_id": "W_kwDOAA6qDM4HbG6o",
+    "name": "GH Actions CI reporting",
+    "path": ".github/workflows/ci-report.yml",
+    "state": "active",
+    "created_at": "2024-10-25T09:53:00.000Z",
+    "updated_at": "2024-10-25T09:53:00.000Z",
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm/actions/workflows/124546728",
+    "html_url": "https://github.com/hibernate/hibernate-orm/blob/main/.github/workflows/ci-report.yml",
+    "badge_url": "https://github.com/hibernate/hibernate-orm/workflows/GH%20Actions%20CI%20reporting/badge.svg"
+  },
+  "repository": {
+    "id": 961036,
+    "node_id": "MDEwOlJlcG9zaXRvcnk5NjEwMzY=",
+    "name": "hibernate-orm",
+    "full_name": "hibernate/hibernate-orm",
+    "private": false,
+    "owner": {
+      "login": "hibernate",
+      "id": 348262,
+      "node_id": "MDEyOk9yZ2FuaXphdGlvbjM0ODI2Mg==",
+      "avatar_url": "https://avatars.githubusercontent.com/u/348262?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/hibernate",
+      "html_url": "https://github.com/hibernate",
+      "type": "Organization"
+    },
+    "html_url": "https://github.com/hibernate/hibernate-orm",
+    "description": "Hibernate's core Object/Relational Mapping functionality",
+    "fork": false,
+    "url": "https://api.github.com/repos/hibernate/hibernate-orm"
+  },
+  "organization": {
+    "login": "hibernate",
+    "id": 348262
+  },
+  "sender": {
+    "login": "mbladel",
+    "id": 25681369
+  },
+  "installation": {
+    "id": 15390286,
+    "node_id": "MDIzOkludGVncmF0aW9uSW5zdGFsbGF0aW9uMTUzOTAyODY="
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `workflowRunCompleted` handler to `ExtractDevelocityBuildScans` that listens for `workflow_run.completed` events and triggers the same Develocity build scan extraction as the existing `checkRunCompleted` handler
- Add tests for both the existing `check_run` handlers (GitHub Actions and Jenkins) and the new `workflow_run` handler

Closes #318

## Context

Some Hibernate projects (e.g. hibernate-orm) use a two-stage CI setup: a main CI workflow runs tests, then a separate reporting workflow (`ci-report.yml`, triggered by `workflow_run`) uploads Develocity build scans. The reporting workflow doesn't produce a `check_run` event the bot can react to, so Develocity reports were never created for these projects.

## Notes

- The GitHub App must also subscribe to `workflow_run` events in its settings
- The GitHub App needs at least read-level "Actions" permission to receive `workflow_run` events

## Test plan

- [x] All existing tests pass
- [x] New test: GitHub Actions check_run triggers build scan extraction
- [x] New test: Jenkins check_run triggers build scan extraction
- [x] New test: No config → no action
- [x] New test: Own check_run ("Develocity Build Scans") is ignored
- [x] New test: workflow_run completion triggers build scan extraction