### PR TITLE
Forbid fixup/squash commits in pull requests

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -196,6 +196,7 @@ public class CheckPullRequestContributionRules {
 	}
 
 	static class MergeCommitsCheck extends PullRequestCheck {
+		private static final int MAX_COMMITS = 100;
 
 		MergeCommitsCheck() {
 			super( "Contribution — Merge commits" );
@@ -203,6 +204,17 @@ public class CheckPullRequestContributionRules {
 
 		@Override
 		public void perform(PullRequestCheckRunContext context, PullRequestCheckRunOutput output) throws IOException {
+			String mergeCommitRuleName = "The pull request should not contain merge commits";
+			String fixupSquashRuleName = "The pull request should not contain fixup! or squash! commits";
+
+			if ( context.pullRequest.getCommits() > MAX_COMMITS ) {
+				String tooManyCommits = "Too many commits (%d) to process; the pull request is probably targeting the wrong branch."
+						.formatted( context.pullRequest.getCommits() );
+				output.rule( mergeCommitRuleName ).failed( tooManyCommits );
+				output.rule( fixupSquashRuleName ).failed( tooManyCommits );
+				return;
+			}
+
 			List<String> mergeCommitShas = new ArrayList<>();
 			List<String> fixupSquashCommitShas = new ArrayList<>();
 			for ( GHPullRequestCommitDetail commitDetail : context.pullRequest.listCommits() ) {
@@ -215,8 +227,7 @@ public class CheckPullRequestContributionRules {
 				}
 			}
 
-			PullRequestCheckRunRule mergeCommitRule = output.rule(
-					"The pull request should not contain merge commits" );
+			PullRequestCheckRunRule mergeCommitRule = output.rule( mergeCommitRuleName );
 			if ( mergeCommitShas.isEmpty() ) {
 				mergeCommitRule.passed();
 			}
@@ -232,8 +243,7 @@ public class CheckPullRequestContributionRules {
 				);
 			}
 
-			PullRequestCheckRunRule fixupSquashRule = output.rule(
-					"The pull request should not contain fixup! or squash! commits" );
+			PullRequestCheckRunRule fixupSquashRule = output.rule( fixupSquashRuleName );
 			if ( fixupSquashCommitShas.isEmpty() ) {
 				fixupSquashRule.passed();
 			}
@@ -270,6 +280,16 @@ public class CheckPullRequestContributionRules {
 
 		@Override
 		public void doPerform(PullRequestCheckRunContext context, PullRequestCheckRunOutput output) throws IOException {
+			String commitRuleName = "All commit messages should start with a JIRA issue key matching pattern `"
+					+ issueKeyPattern + "`";
+
+			if ( context.pullRequest.getCommits() > MergeCommitsCheck.MAX_COMMITS ) {
+				output.rule( commitRuleName )
+						.failed( "Too many commits (%d) to process; the pull request is probably targeting the wrong branch."
+								.formatted( context.pullRequest.getCommits() ) );
+				return;
+			}
+
 			String title = context.pullRequest.getTitle();
 			String body = context.pullRequest.getBody();
 
@@ -287,9 +307,7 @@ public class CheckPullRequestContributionRules {
 				}
 			}
 
-			PullRequestCheckRunRule commitRule =
-					output.rule( "All commit messages should start with a JIRA issue key matching pattern `"
-							+ issueKeyPattern + "`" );
+			PullRequestCheckRunRule commitRule = output.rule( commitRuleName );
 			if ( commitsWithMessageNotStartingWithIssueKey.isEmpty() ) {
 				commitRule.passed();
 			}

--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -204,25 +204,48 @@ public class CheckPullRequestContributionRules {
 		@Override
 		public void perform(PullRequestCheckRunContext context, PullRequestCheckRunOutput output) throws IOException {
 			List<String> mergeCommitShas = new ArrayList<>();
+			List<String> fixupSquashCommitShas = new ArrayList<>();
 			for ( GHPullRequestCommitDetail commitDetail : context.pullRequest.listCommits() ) {
 				if ( commitDetail.getParents().length > 1 ) {
 					mergeCommitShas.add( commitDetail.getSha() );
 				}
+				String message = commitDetail.getCommit().getMessage();
+				if ( message.startsWith( "fixup! " ) || message.startsWith( "squash! " ) ) {
+					fixupSquashCommitShas.add( commitDetail.getSha() );
+				}
 			}
 
-			PullRequestCheckRunRule rule = output.rule( "The pull request should not contain merge commits" );
+			PullRequestCheckRunRule mergeCommitRule = output.rule(
+					"The pull request should not contain merge commits" );
 			if ( mergeCommitShas.isEmpty() ) {
-				rule.passed();
+				mergeCommitRule.passed();
 			}
 			else {
 				String targetBranch = context.pullRequest.getBase().getRef();
-				rule.failed(
+				mergeCommitRule.failed(
 						"Offending commits: "
 								+ String.join( ", ", mergeCommitShas.stream().map( sha -> "`" + sha + "`" ).toList() )
 								+ ".\n\nPlease [rebase](https://docs.github.com/en/get-started/using-git/about-git-rebase)"
 								+ " your branch on `" + targetBranch + "` and"
 								+ " [force-push](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message#amending-older-or-multiple-commit-messages),"
 								+ " rather than merging the target branch into your pull request branch."
+				);
+			}
+
+			PullRequestCheckRunRule fixupSquashRule = output.rule(
+					"The pull request should not contain fixup! or squash! commits" );
+			if ( fixupSquashCommitShas.isEmpty() ) {
+				fixupSquashRule.passed();
+			}
+			else {
+				fixupSquashRule.failed(
+						"Offending commits: "
+								+ String.join( ", ",
+										fixupSquashCommitShas.stream().map( sha -> "`" + sha + "`" ).toList() )
+								+ ".\n\nPlease squash your fixup/squash commits using"
+								+ " [interactive rebase](https://git-scm.com/docs/git-rebase#_interactive_mode)"
+								+ " and [force-push](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message#amending-older-or-multiple-commit-messages)"
+								+ " before merging."
 				);
 			}
 		}

--- a/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesFixupSquashTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/CheckPullRequestContributionRulesFixupSquashTest.java
@@ -1,0 +1,186 @@
+package org.hibernate.infra.bot.tests;
+
+import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.quarkiverse.githubapp.testing.GitHubAppTest;
+import io.quarkus.test.junit.QuarkusTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.kohsuke.github.GHCheckRun;
+import org.kohsuke.github.GHCheckRunBuilder;
+import org.kohsuke.github.GHEvent;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@QuarkusTest
+@GitHubAppTest
+@ExtendWith(MockitoExtension.class)
+public class CheckPullRequestContributionRulesFixupSquashTest extends AbstractPullRequestTest {
+	@Test
+	void noFixupSquashCommits() throws IOException {
+		long repoId = 344815557L;
+		long prId = 585627026L;
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( """
+									jira:
+									  projectKey: "HSEARCH"
+									""" );
+
+					GHRepository repoMock = mocks.repository( "yrodiere/hibernate-github-bot-playground" );
+					when( repoMock.getId() ).thenReturn( repoId );
+
+					PullRequestMockHelper.start( mocks, prId, repoMock )
+							.commit( "HSEARCH-1111 Correct message" )
+							.comment( "Some comment" )
+							.comment( "Some other comment" );
+
+					mockCheckRuns( repoMock, "6e9f11a1e2946b207c6eb245ec942f2b5a3ea156" );
+				} )
+				.when()
+				.payloadFromClasspath( "/pullrequest-opened-hsearch-1111.json" )
+				.event( GHEvent.PULL_REQUEST )
+				.then()
+				.github( mocks -> {
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.SUCCESS );
+
+					var outputCaptor = ArgumentCaptor.forClass( GHCheckRunBuilder.Output.class );
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).add( outputCaptor.capture() );
+					var output = outputCaptor.getValue();
+					assertThat( output )
+							.extracting( "title", InstanceOfAssertFactories.STRING )
+							.contains( "All rules passed" );
+
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+
+	@Test
+	void hasFixupCommit() throws IOException {
+		long repoId = 344815557L;
+		long prId = 585627026L;
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( """
+									jira:
+									  projectKey: "HSEARCH"
+									""" );
+
+					GHRepository repoMock = mocks.repository( "yrodiere/hibernate-github-bot-playground" );
+					when( repoMock.getId() ).thenReturn( repoId );
+
+					PullRequestMockHelper.start( mocks, prId, repoMock )
+							.commit( "HSEARCH-1111 Some work" )
+							.commit( "fixup! HSEARCH-1111 Some work", "abc123fixup" )
+							.comment( "Some comment" )
+							.comment( "Some other comment" );
+
+					mockCheckRuns( repoMock, "6e9f11a1e2946b207c6eb245ec942f2b5a3ea156" );
+				} )
+				.when()
+				.payloadFromClasspath( "/pullrequest-opened-hsearch-1111.json" )
+				.event( GHEvent.PULL_REQUEST )
+				.then()
+				.github( mocks -> {
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.FAILURE );
+
+					var outputCaptor = ArgumentCaptor.forClass( GHCheckRunBuilder.Output.class );
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).add( outputCaptor.capture() );
+					var output = outputCaptor.getValue();
+					assertThat( output )
+							.extracting( "title", InstanceOfAssertFactories.STRING )
+							.isEqualTo( "The pull request should not contain fixup! or squash! commits" );
+					assertThat( output )
+							.extracting( "summary", InstanceOfAssertFactories.STRING )
+							.contains(
+									"The pull request should not contain fixup! or squash! commits",
+									"abc123fixup",
+									"interactive rebase",
+									"https://git-scm.com/docs/git-rebase#_interactive_mode"
+							);
+
+					GHPullRequest prMock = mocks.pullRequest( prId );
+					ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass( String.class );
+					verify( prMock ).comment( messageCaptor.capture() );
+					assertThat( messageCaptor.getValue() )
+							.contains(
+									"The pull request should not contain fixup! or squash! commits",
+									"abc123fixup",
+									"interactive rebase",
+									"https://git-scm.com/docs/git-rebase#_interactive_mode"
+							);
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+
+	@Test
+	void hasSquashCommit() throws IOException {
+		long repoId = 344815557L;
+		long prId = 585627026L;
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( """
+									jira:
+									  projectKey: "HSEARCH"
+									""" );
+
+					GHRepository repoMock = mocks.repository( "yrodiere/hibernate-github-bot-playground" );
+					when( repoMock.getId() ).thenReturn( repoId );
+
+					PullRequestMockHelper.start( mocks, prId, repoMock )
+							.commit( "HSEARCH-1111 Some work" )
+							.commit( "squash! HSEARCH-1111 Some work", "def456squash" )
+							.comment( "Some comment" )
+							.comment( "Some other comment" );
+
+					mockCheckRuns( repoMock, "6e9f11a1e2946b207c6eb245ec942f2b5a3ea156" );
+				} )
+				.when()
+				.payloadFromClasspath( "/pullrequest-opened-hsearch-1111.json" )
+				.event( GHEvent.PULL_REQUEST )
+				.then()
+				.github( mocks -> {
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).withConclusion( GHCheckRun.Conclusion.FAILURE );
+
+					var outputCaptor = ArgumentCaptor.forClass( GHCheckRunBuilder.Output.class );
+					verify( mergeCommitsCheckRunUpdateBuilderMock ).add( outputCaptor.capture() );
+					var output = outputCaptor.getValue();
+					assertThat( output )
+							.extracting( "title", InstanceOfAssertFactories.STRING )
+							.isEqualTo( "The pull request should not contain fixup! or squash! commits" );
+					assertThat( output )
+							.extracting( "summary", InstanceOfAssertFactories.STRING )
+							.contains(
+									"The pull request should not contain fixup! or squash! commits",
+									"def456squash",
+									"interactive rebase",
+									"https://git-scm.com/docs/git-rebase#_interactive_mode"
+							);
+
+					GHPullRequest prMock = mocks.pullRequest( prId );
+					ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass( String.class );
+					verify( prMock ).comment( messageCaptor.capture() );
+					assertThat( messageCaptor.getValue() )
+							.contains(
+									"The pull request should not contain fixup! or squash! commits",
+									"def456squash",
+									"interactive rebase",
+									"https://git-scm.com/docs/git-rebase#_interactive_mode"
+							);
+					verifyNoMoreInteractions( mocks.ghObjects() );
+				} );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a second rule to the existing "Contribution — Merge commits" check that detects commits starting with `fixup! ` or `squash! `
- On failure, lists offending commit SHAs and suggests squashing via interactive rebase + force-push
- Adds 3 test cases: no fixup/squash commits (passes), has fixup commit (fails), has squash commit (fails)

Closes #9

## Test plan

- [x] All 50 existing + new tests pass (`mvn test`)
- [ ] Deploy and verify the check appears on a PR with a `fixup!` commit