### PR TITLE
Fix rerun event handling for all checks

### DIFF
--- a/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
+++ b/src/main/java/org/hibernate/infra/bot/CheckPullRequestContributionRules.java
@@ -69,7 +69,8 @@ public class CheckPullRequestContributionRules {
 			@ConfigFile("hibernate-github-bot.yml") RepositoryConfig repositoryConfig,
 			@ConfigFile("PULL_REQUEST_TEMPLATE.md") String pullRequestTemplate,
 			GitHub gitHub) throws IOException {
-		for ( GHPullRequest pullRequest : payload.getCheckRun().getPullRequests() ) {
+		for ( GHPullRequest pullRequest : associatedPullRequests( payload.getRepository(),
+				payload.getCheckRun().getPullRequests(), payload.getCheckRun().getHeadSha() ) ) {
 			checkPullRequestContributionRules( payload.getRepository(), gitHub, repositoryConfig, pullRequestTemplate, pullRequest );
 		}
 	}
@@ -78,9 +79,24 @@ public class CheckPullRequestContributionRules {
 			@ConfigFile("hibernate-github-bot.yml") RepositoryConfig repositoryConfig,
 			@ConfigFile("PULL_REQUEST_TEMPLATE.md") String pullRequestTemplate,
 			GitHub gitHub) throws IOException {
-		for ( GHPullRequest pullRequest : payload.getCheckSuite().getPullRequests() ) {
+		for ( GHPullRequest pullRequest : associatedPullRequests( payload.getRepository(),
+				payload.getCheckSuite().getPullRequests(), payload.getCheckSuite().getHeadSha() ) ) {
 			checkPullRequestContributionRules( payload.getRepository(), gitHub, repositoryConfig, pullRequestTemplate, pullRequest );
 		}
+	}
+
+	private List<GHPullRequest> associatedPullRequests(GHRepository repository,
+			List<GHPullRequest> pullRequests, String headSha) throws IOException {
+		if ( !pullRequests.isEmpty() ) {
+			return pullRequests;
+		}
+		// The pull_requests list in check_run/check_suite webhook payloads can be empty
+		// for app-created check runs. Fall back to looking up PRs by commit SHA.
+		var commit = repository.getCommit( headSha );
+		if ( commit == null ) {
+			return List.of();
+		}
+		return commit.listPullRequests().toList();
 	}
 
 	private void checkPullRequestContributionRules(GHRepository repository, GitHub gitHub, RepositoryConfig repositoryConfig,

--- a/src/main/java/org/hibernate/infra/bot/ExtractDevelocityBuildScans.java
+++ b/src/main/java/org/hibernate/infra/bot/ExtractDevelocityBuildScans.java
@@ -28,6 +28,7 @@ import com.gradle.develocity.model.BuildsQuery;
 
 import io.quarkiverse.githubapp.ConfigFile;
 import io.quarkiverse.githubapp.event.CheckRun;
+import io.quarkiverse.githubapp.event.CheckSuite;
 import io.quarkiverse.githubapp.event.WorkflowRun;
 import io.quarkus.logging.Log;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -58,6 +59,22 @@ public class ExtractDevelocityBuildScans {
 		}
 		String sha = checkRun.getHeadSha();
 		extractCIBuildScans( repository, repositoryConfig.develocity.buildScan, sha );
+	}
+
+	void checkSuiteRerequested(@CheckSuite.Rerequested GHEventPayload.CheckSuite payload,
+			@ConfigFile("hibernate-github-bot.yml") RepositoryConfig repositoryConfig) {
+		if ( repositoryConfig == null
+				|| repositoryConfig.develocity == null
+				|| repositoryConfig.develocity.buildScan == null ) {
+			return;
+		}
+		var buildScanConfig = repositoryConfig.develocity.buildScan;
+		if ( !buildScanConfig.addCheck ) {
+			return;
+		}
+		var repository = payload.getRepository();
+		var sha = payload.getCheckSuite().getHeadSha();
+		extractCIBuildScans( repository, buildScanConfig, sha );
 	}
 
 	void workflowRunCompleted(@WorkflowRun.Completed GHEventPayload.WorkflowRun payload,

--- a/src/test/java/org/hibernate/infra/bot/tests/ExtractDevelocityBuildScansTest.java
+++ b/src/test/java/org/hibernate/infra/bot/tests/ExtractDevelocityBuildScansTest.java
@@ -4,6 +4,7 @@ import static io.quarkiverse.githubapp.testing.GitHubAppTesting.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -206,6 +207,97 @@ public class ExtractDevelocityBuildScansTest {
 					String query = queryCaptor.getValue().getQuery();
 					assertThat( query )
 							.contains( "value:\"Git commit id=" + WORKFLOW_HEAD_SHA + "\"" );
+				} );
+	}
+
+	@Test
+	void checkSuiteRerequested() throws IOException {
+		given()
+				.github( mocks -> {
+					mocks.configFile( "hibernate-github-bot.yml" )
+							.fromString( DEVELOCITY_BUILD_SCAN_CONFIG );
+
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+
+					mockGetCheckRuns( repoMock, HEAD_SHA,
+							mockGitHubActionsCheckRun( HEAD_SHA ) );
+					mockDevelocityCheckRun( repoMock, HEAD_SHA );
+				} )
+				.when()
+				.payloadFromString( """
+						{
+						  "action": "rerequested",
+						  "check_suite": {
+						    "id": 73312401811,
+						    "head_sha": "%s",
+						    "head_branch": "some-branch",
+						    "status": "queued",
+						    "conclusion": null,
+						    "pull_requests": []
+						  },
+						  "repository": {
+						    "id": 961036,
+						    "name": "hibernate-orm",
+						    "full_name": "%s",
+						    "private": false,
+						    "owner": {
+						      "login": "hibernate",
+						      "id": 348262
+						    }
+						  },
+						  "installation": {
+						    "id": 15390286
+						  }
+						}
+						""".formatted( HEAD_SHA, REPO_NAME ) )
+				.event( GHEvent.CHECK_SUITE )
+				.then()
+				.github( mocks -> {
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+					verify( repoMock ).createCheckRun( "Develocity Build Scans", HEAD_SHA );
+					verify( repoMock ).updateCheckRun( DEVELOCITY_CHECK_RUN_ID );
+					verify( develocityBuildsApiMock ).getBuilds( any() );
+				} );
+	}
+
+	@Test
+	void checkSuiteRerequested_noConfig() throws IOException {
+		given()
+				.github( mocks -> {
+				} )
+				.when()
+				.payloadFromString( """
+						{
+						  "action": "rerequested",
+						  "check_suite": {
+						    "id": 73312401811,
+						    "head_sha": "%s",
+						    "head_branch": "some-branch",
+						    "status": "queued",
+						    "conclusion": null,
+						    "pull_requests": []
+						  },
+						  "repository": {
+						    "id": 961036,
+						    "name": "hibernate-orm",
+						    "full_name": "%s",
+						    "private": false,
+						    "owner": {
+						      "login": "hibernate",
+						      "id": 348262
+						    }
+						  },
+						  "installation": {
+						    "id": 15390286
+						  }
+						}
+						""".formatted( HEAD_SHA, REPO_NAME ) )
+				.event( GHEvent.CHECK_SUITE )
+				.then()
+				.github( mocks -> {
+					GHRepository repoMock = mocks.repository( REPO_NAME );
+					verify( repoMock, never() ).createCheckRun( "Develocity Build Scans", HEAD_SHA );
+					verifyNoMoreInteractions( develocityBuildsApiMock );
 				} );
 	}
 


### PR DESCRIPTION
## Summary
- **CheckPullRequestContributionRules**: The `checkRunRequested` and `checkSuiteRequested` handlers iterated over `getPullRequests()` from the webhook payload, which can be empty for app-created check runs. Added a fallback that looks up PRs by commit SHA via `GHCommit.listPullRequests()`.
- **ExtractDevelocityBuildScans**: Added a `@CheckSuite.Rerequested` handler so that "Re-run all checks" also re-extracts Develocity build scans. Previously only `@CheckRun.Rerequested` was handled.

## Test plan
- [x] Added `checkSuiteRerequested` test verifying build scans are re-extracted on check suite rerun
- [x] Added `checkSuiteRerequested_noConfig` test verifying no-op when Develocity config is absent
- [x] All 52 existing tests pass